### PR TITLE
tool/convert-qa

### DIFF
--- a/docs/tools/convert-qa.md
+++ b/docs/tools/convert-qa.md
@@ -1,24 +1,86 @@
-# Convert-qa
-
-Convert-qa er et værktøj der bruges til undersøge om filerne er konverteret korrekt, ved at sammenligne originale filer med de konverterede filer.
+# Convert QA
 
 ## Installation
-Convert-qa skal installeres via master branch med [pipx](pipx.md):
 
-```powershell
-pipx install git+https://github.com/aarhusstadsarkiv/convert-qa.git
+Preferred way is to install with pipx: `pipx install git+https://github.com/aarhusstadsarkiv/convert-qa.git`
+
+## convert-compare
+
+This tool provides a way for you to easily compare files between original, master and statutory
+
+The script requires that you specify the paths to original and master documents:
+
+- `convert-compare --master path/to/master/files --original path/to/original/files`
+
+Statutory documents can also be specified with `--statutory` but is optional
+
+The tool only reads from the metadata database for the original documents.
+
+Default output is set to `./comparison_output`, this can be changed with `-o` and `--output`.
+
+```
+convert-compare [-h] [--original ORIGINAL] [--master MASTER] [--statutory STATUTORY] [--output OUTPUT] [--digiarch]
+
+options:
+  -h, --help            show this help message and exit
+  --original ORIGINAL   directory pointing to original documents containing the metadata folder
+  --master MASTER       directory pointing to master documents
+  --statutory STATUTORY
+                        (optional) directory pointing to statutory documents
+  --output OUTPUT       directory to output files into
+  --digiarch            generate metadata folder with digiarch
 ```
 
-Test efterfølgende installationen med følgende kommando:
+## convert-encoding
 
-```powershell
-convert-qa --version
+This tool takes a list of Open Document files and check the text inside the content.xml file for unusual character
+sequences.
+
+The characters are searched within tags, they must be surrounded by ASCII characters and not included in the
+optional `IGNORE` argument.
+
+```
+convert-encoding [-h] [--ignore IGNORE] files [files ...]
+
+positional arguments:                                                                                                                                                                                                          
+  files            the files to check                                                                                                                                                                                          
+                                                                                                                                                                                                                               
+options:                                                                                                                                                                                                                       
+  -h, --help       show this help message and exit
+  --ignore IGNORE  extra characters to ignore
 ```
 
-Når man skal opdatere convert-qa, bruges `pipx` med `--upgrade`:
+## clean-empty-columns
 
-```powershell
-pipx upgrade convert-qa
+Take a list of databases or archive folders and check each table for empty columns (all values either null or ''). Completely empty tables will also be removed.
+
+Empty columns are removed only if the `--commit` option is used and are otherwise ignored.
+
+```
+clean-empty-columns [-h] [--commit] [--log-file LOG_FILE] {archive,sqlite} files [files ...]
+
+positional arguments:
+  {archive,sqlite}     whether the files are archives or SQLite databases
+  files                the databases/archives to clean
+
+options:
+  -h, --help           show this help message and exit
+  --commit             commit changes to database
+  --log-file LOG_FILE  write change events to log file
 ```
 
-## Brug
+## remove-tables
+
+Remove tables from a given archive.
+
+```
+remove-tables [-h] [--log-file LOG_FILE] archive tables [tables ...]
+
+positional arguments:
+  archive              the path to the archive
+  tables               the tables to remove
+
+options:
+  -h, --help           show this help message and exit
+  --log-file LOG_FILE  write change events to log file
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,12 @@ nav:
       - Byteheader: tools/byteheader.md
       - Convertool: tools/convertool.md
       - Convert-unmanaged: tools/convert-unmanaged.md
-      - Convert-qa: tools/convert-qa.md
+      - convert-qa:
+          - tools/convert-qa.md
+          - convert-compare: tools/convert-qa#convert-compare
+          - convert-encoding: tools/convert-qa#convert-encoding
+          - clean-empty-columns: tools/convert-qa#clean-empty-columns
+          - remove-tables: tools/convert-qa#remove-tables
       - Digiarch: tools/digiarch.md
       - Gisprocessor: tools/gis_processor.md
       - LibreOffice: tools/libreoffice.md


### PR DESCRIPTION
Dokumentation er opdateret https://github.com/aarhusstadsarkiv/convert-qa med alle de nye værktøjer: convert-compare, convert-encoding, clean-empty-columns, remove-tables.

Dokumentationen er på engelsk lige nu, men det kan oversættes før vi merge den.